### PR TITLE
Simplify SignalR command routing by convention

### DIFF
--- a/SourceCode/AgOpenGPS.Api.Client/Commands/SimulatorCommands.cs
+++ b/SourceCode/AgOpenGPS.Api.Client/Commands/SimulatorCommands.cs
@@ -1,5 +1,4 @@
 using AgOpenGPS.Api.Client.Models;
-
 namespace AgOpenGPS.Api.Client.Commands
 {
     /// <summary>

--- a/SourceCode/AgOpenGPS.Api.Client/Factories/BackendClientFactory.cs
+++ b/SourceCode/AgOpenGPS.Api.Client/Factories/BackendClientFactory.cs
@@ -38,7 +38,8 @@ namespace AgOpenGPS.Api.Client.Factories
             var hubConnection = builder.Build();
 
             // Create and return SignalRBackendClient with injected HubConnection
-            return new SignalRBackendClient(hubConnection);
+            var commandRouter = new SignalRCommandRouter();
+            return new SignalRBackendClient(hubConnection, commandRouter);
         }
     }
 }

--- a/SourceCode/AgOpenGPS.Api.Client/SignalR/ISignalRCommandRouter.cs
+++ b/SourceCode/AgOpenGPS.Api.Client/SignalR/ISignalRCommandRouter.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace AgOpenGPS.Api.Client.SignalR
+{
+    /// <summary>
+    /// Resolves SignalR hub method names for client command types.
+    /// </summary>
+    public interface ISignalRCommandRouter
+    {
+        /// <summary>
+        /// Attempts to resolve the hub method name for the specified command type.
+        /// </summary>
+        /// <param name="commandType">Command type implementing <c>ICommand</c>.</param>
+        /// <param name="hubMethodName">Resolved hub method name when available.</param>
+        /// <returns><c>true</c> when the command type has a registered hub method; otherwise <c>false</c>.</returns>
+        bool TryGetHubMethodForCommand(Type commandType, out string hubMethodName);
+
+        /// <summary>
+        /// Resolves the hub method name for the specified command type.
+        /// </summary>
+        /// <param name="commandType">Command type implementing <c>ICommand</c>.</param>
+        /// <returns>The hub method name associated with the command.</returns>
+        /// <exception cref="NotSupportedException">Thrown when the command type does not have a mapping.</exception>
+        string GetHubMethodForCommand(Type commandType);
+    }
+}

--- a/SourceCode/AgOpenGPS.Api.Client/SignalR/SignalRBackendClient.cs
+++ b/SourceCode/AgOpenGPS.Api.Client/SignalR/SignalRBackendClient.cs
@@ -18,15 +18,17 @@ namespace AgOpenGPS.Api.Client.SignalR
     {
         private readonly HubConnection _hubConnection;
         private readonly Subject<ApplicationState> _stateSubject = new Subject<ApplicationState>();
+        private readonly ISignalRCommandRouter _commandRouter;
         private IDisposable? _subscription;
 
         /// <summary>
         /// Initializes a new instance of SignalRBackendClient.
         /// </summary>
         /// <param name="hubConnection">Pre-configured HubConnection to use for communication</param>
-        public SignalRBackendClient(HubConnection hubConnection)
+        public SignalRBackendClient(HubConnection hubConnection, ISignalRCommandRouter commandRouter)
         {
             _hubConnection = hubConnection ?? throw new ArgumentNullException(nameof(hubConnection));
+            _commandRouter = commandRouter ?? throw new ArgumentNullException(nameof(commandRouter));
 
             // Register handler for state update messages (backend → client)
             _hubConnection.On<ApplicationState>("ReceiveState", state =>
@@ -56,18 +58,13 @@ namespace AgOpenGPS.Api.Client.SignalR
             if (!IsConnected)
                 throw new InvalidOperationException("Not connected to backend. Call ConnectAsync() first.");
 
-            // Route command to specific hub method based on type
-            // Note: SignalR doesn't support generic hub methods, so we need specific methods for each command type
-            switch (command)
+            if (!_commandRouter.TryGetHubMethodForCommand(command.GetType(), out var hubMethod))
             {
-                case UpdateSimulatorCommand cmd:
-                    await _hubConnection.InvokeAsync("UpdateSimulator", cmd);
-                    break;
-
-                default:
-                    throw new NotSupportedException($"Command type '{command.GetType().Name}' is not supported. " +
-                        "Add a new case to SignalRBackendClient.SendCommandAsync and a corresponding hub method.");
+                throw new NotSupportedException($"Command type '{command.GetType().Name}' is not supported. " +
+                    "Ensure the command type is discovered by SignalRCommandRouter.");
             }
+
+            await _hubConnection.InvokeAsync(hubMethod, command);
         }
 
         /// <inheritdoc />

--- a/SourceCode/AgOpenGPS.Api.Client/SignalR/SignalRCommandRouter.cs
+++ b/SourceCode/AgOpenGPS.Api.Client/SignalR/SignalRCommandRouter.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using AgOpenGPS.Api.Client.Commands;
+
+namespace AgOpenGPS.Api.Client.SignalR
+{
+    /// <summary>
+    /// Provides hub method resolution for SignalR command dispatch.
+    /// </summary>
+    public sealed class SignalRCommandRouter : ISignalRCommandRouter
+    {
+        private readonly IReadOnlyDictionary<Type, string> _commandHubMap;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SignalRCommandRouter"/> class.
+        /// </summary>
+        /// <param name="assemblies">Optional set of assemblies to scan for <see cref="ICommand"/> implementations.</param>
+        public SignalRCommandRouter(IEnumerable<Assembly>? assemblies = null)
+        {
+            var assembliesToScan = (assemblies ?? new[] { typeof(ICommand).Assembly })
+                .Where(a => a != null)
+                .Distinct()
+                .ToArray();
+
+            _commandHubMap = new ReadOnlyDictionary<Type, string>(BuildCommandHubMap(assembliesToScan));
+        }
+
+        /// <inheritdoc />
+        public bool TryGetHubMethodForCommand(Type commandType, out string hubMethodName)
+        {
+            if (commandType == null)
+                throw new ArgumentNullException(nameof(commandType));
+
+            if (!_commandHubMap.TryGetValue(commandType, out hubMethodName!))
+            {
+                hubMethodName = string.Empty;
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
+        public string GetHubMethodForCommand(Type commandType)
+        {
+            if (TryGetHubMethodForCommand(commandType, out var hubMethodName))
+            {
+                return hubMethodName;
+            }
+
+            throw new NotSupportedException(
+                $"Command type '{commandType?.Name ?? "<null>"}' does not have a SignalR hub mapping. " +
+                "Ensure the command type is included in the assemblies scanned by SignalRCommandRouter.");
+        }
+
+        private static Dictionary<Type, string> BuildCommandHubMap(IEnumerable<Assembly> assemblies)
+        {
+            var map = new Dictionary<Type, string>();
+
+            foreach (var assembly in assemblies)
+            {
+                foreach (var type in assembly.GetTypes())
+                {
+                    if (type.IsAbstract || type.IsInterface)
+                        continue;
+
+                    if (!typeof(ICommand).IsAssignableFrom(type))
+                        continue;
+
+                    var hubMethodName = ResolveHubMethodName(type);
+                    map[type] = hubMethodName;
+                }
+            }
+
+            return map;
+        }
+
+        private static string ResolveHubMethodName(Type commandType)
+        {
+            var typeName = commandType.Name;
+            if (typeName.EndsWith("Command", StringComparison.Ordinal))
+            {
+                return typeName.Substring(0, typeName.Length - "Command".Length);
+            }
+
+            return typeName;
+        }
+    }
+}

--- a/SourceCode/Tests/AgOpenGPS.API.IntegrationTests/GpsPacketProcessingTests.cs
+++ b/SourceCode/Tests/AgOpenGPS.API.IntegrationTests/GpsPacketProcessingTests.cs
@@ -31,7 +31,7 @@ public class GpsPacketProcessingTests : BaseIntegrationTest
     {
         // Setup SignalR connection for event-driven testing
         _hubConnection = CreateTestHubConnection("/statehub");
-        _subscriber = new SignalRBackendClient(_hubConnection);
+        _subscriber = new SignalRBackendClient(_hubConnection, new SignalRCommandRouter());
         _receivedStates = new ConcurrentQueue<ApplicationState>();
 
         await _subscriber.ConnectAsync();

--- a/SourceCode/Tests/AgOpenGPS.API.IntegrationTests/SimulatorUnifiedCommandTests.cs
+++ b/SourceCode/Tests/AgOpenGPS.API.IntegrationTests/SimulatorUnifiedCommandTests.cs
@@ -27,7 +27,7 @@ public class SimulatorUnifiedCommandTests : BaseIntegrationTest
         _receivedStates.Clear();
 
         var hubConnection = CreateTestHubConnection("/statehub");
-        _backendClient = new SignalRBackendClient(hubConnection);
+        _backendClient = new SignalRBackendClient(hubConnection, new SignalRCommandRouter());
         await _backendClient.ConnectAsync();
     }
 
@@ -455,7 +455,7 @@ public class SimulatorUnifiedCommandTests : BaseIntegrationTest
 
         // Arrange - Create second client
         var hubConnection2 = CreateTestHubConnection("/statehub");
-        var backendClient2 = new SignalRBackendClient(hubConnection2);
+        var backendClient2 = new SignalRBackendClient(hubConnection2, new SignalRCommandRouter());
         var receivedStates2 = new ConcurrentQueue<ApplicationState>();
         var semaphore1 = new SemaphoreSlim(0, 1);
         var semaphore2 = new SemaphoreSlim(0, 1);

--- a/SourceCode/Tests/AgOpenGPS.Api.Tests/SignalRCommandRouterTests.cs
+++ b/SourceCode/Tests/AgOpenGPS.Api.Tests/SignalRCommandRouterTests.cs
@@ -1,0 +1,73 @@
+using System;
+using AgOpenGPS.Api.Client.Commands;
+using AgOpenGPS.Api.Client.SignalR;
+
+namespace AgOpenGPS.Api.Tests
+{
+    public class SignalRCommandRouterTests
+    {
+        private static SignalRCommandRouter CreateRouter()
+            => new SignalRCommandRouter(new[] { typeof(SignalRCommandRouterTests).Assembly });
+
+        [Test]
+        public void GetHubMethodForCommand_ShouldTrimCommandSuffix()
+        {
+            var router = CreateRouter();
+
+            var name = router.GetHubMethodForCommand(typeof(DefaultNameCommand));
+
+            Assert.That(name, Is.EqualTo("DefaultName"));
+        }
+
+        [Test]
+        public void GetHubMethodForCommand_ShouldUseFullNameWhenNoSuffixPresent()
+        {
+            var router = CreateRouter();
+
+            var name = router.GetHubMethodForCommand(typeof(Ping));
+
+            Assert.That(name, Is.EqualTo("Ping"));
+        }
+
+        [Test]
+        public void GetHubMethodForCommand_ShouldHandleInheritance()
+        {
+            var router = CreateRouter();
+
+            var name = router.GetHubMethodForCommand(typeof(DerivedCommand));
+
+            Assert.That(name, Is.EqualTo("Derived"));
+        }
+
+        [Test]
+        public void GetHubMethodForCommand_ShouldThrow_WhenCommandNotDiscovered()
+        {
+            var router = new SignalRCommandRouter(Array.Empty<System.Reflection.Assembly>());
+
+            Assert.That(() => router.GetHubMethodForCommand(typeof(DefaultNameCommand)),
+                Throws.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void TryGetHubMethodForCommand_ShouldReturnFalse_WhenCommandNotDiscovered()
+        {
+            var router = new SignalRCommandRouter(Array.Empty<System.Reflection.Assembly>());
+
+            var result = router.TryGetHubMethodForCommand(typeof(DefaultNameCommand), out var hubMethod);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.False);
+                Assert.That(hubMethod, Is.Empty);
+            });
+        }
+
+        private sealed record DefaultNameCommand() : ICommand;
+
+        private sealed record Ping() : ICommand;
+
+        private abstract record BaseCommand : ICommand;
+
+        private sealed record DerivedCommand() : BaseCommand;
+    }
+}


### PR DESCRIPTION
## Summary
- remove SignalRHubMethodAttribute and rely on convention-based hub names for ICommand implementations
- update the SignalR command router to discover commands by type and trim the Command suffix for hub names
- refresh unit coverage and backend client messaging to reflect the convention-based routing

## Testing
- dotnet test SourceCode/AgOpenGPS.sln *(fails: `dotnet` command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916379ec00083308e576d660cf4ed43)